### PR TITLE
update Dockerfile to use local working copy vs remote

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
         clang-10 \
         llvm-10 \
         libc++-dev libc++abi-dev \
-        cmake \        
+        cmake \ 
         libboost1.74-dev \
         ccache \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -38,9 +38,8 @@ ENV CXX=/usr/bin/clang++-10
 
 # ↑ Setup build environment
 # ↓ Build and compile wallet core
-
-RUN git clone https://github.com/trustwallet/wallet-core.git
 WORKDIR /wallet-core
+COPY . .
 
 # Install dependencies
 RUN tools/install-dependencies


### PR DESCRIPTION
Updated Dockerfile:
1. removed extra spaces after `cmake \`
2. use the *current* repo vs a hardcoded public repo `COPY . .`

Test build using this dockerfile succeeds, whereas building using the existing Dockerfile fails on this line: https://github.com/trustwallet/wallet-core/blob/master/codegen/bin/coins#L26

Likely that line needs to be adjusted from:
```
id[0].upcase + id[1..].downcase
```
to
```
id[0].upcase + id[1..-1].downcase
```

But that change seemed out of scope since that function doesn't exist in this repo. 